### PR TITLE
Fix/2 permite publicación de reseña previo a la fecha de reserva

### DIFF
--- a/Ministerio de Turismo/MinTur.BusinessLogic.Test/ResourceManagers/ReviewManagerTest.cs
+++ b/Ministerio de Turismo/MinTur.BusinessLogic.Test/ResourceManagers/ReviewManagerTest.cs
@@ -32,6 +32,9 @@ namespace MinTur.BusinessLogic.Test.ResourceManagers
             Reservation retrievedReservation = CreateReservation();
             Resort retrievedResort = CreateResortWithSpecificId(retrievedReservation.Resort.Id);
             Review createdReview = CreateReview(reviewId, retrievedReservation);
+            Accommodation acc = new Accommodation();
+            acc.CheckOut = DateTime.Today;
+            retrievedReservation.Accommodation = acc;
 
             _reviewMock.SetupAllProperties();
 

--- a/Ministerio de Turismo/MinTur.BusinessLogic/ResourceManagers/ReviewManager.cs
+++ b/Ministerio de Turismo/MinTur.BusinessLogic/ResourceManagers/ReviewManager.cs
@@ -1,6 +1,7 @@
 ﻿using MinTur.BusinessLogicInterface.ResourceManagers;
 using MinTur.DataAccessInterface.Facades;
 using MinTur.Domain.BusinessEntities;
+using MinTur.Exceptions;
 using System;
 
 namespace MinTur.BusinessLogic.ResourceManagers
@@ -23,13 +24,21 @@ namespace MinTur.BusinessLogic.ResourceManagers
             review.Surname = retrievedReservation.Surname;
             review.ResortId = relatedResort.Id;
             review.ReservationId = retrievedReservation.Id;
-            review.ValidOrFail();
-            relatedResort.UpdateResortPunctuation(review);
+            if(DateTime.Today < retrievedReservation.Accommodation.CheckOut)
+            {
+                throw new InvalidRequestDataException("You can only review a place once you have visited it.");
+            }
+            else
+            {
+                review.ValidOrFail();
+                relatedResort.UpdateResortPunctuation(review);
 
-            _repositoryFacade.UpdateResort(relatedResort);
-            int newReviewId = _repositoryFacade.StoreReview(review);
+                _repositoryFacade.UpdateResort(relatedResort);
+                int newReviewId = _repositoryFacade.StoreReview(review);
 
-            return _repositoryFacade.GetReviewById(newReviewId);
+                return _repositoryFacade.GetReviewById(newReviewId);
+            }
+            
         }
 
     }


### PR DESCRIPTION

# :wrench: Bugfix: Permite publicación de reseña previo a la fecha de reserva
closes #2 


#### :information_source: Description:

Se puede hacer reseñas sin haber ido al lugar previamente. Esto puede significar un gran problema a nivel de la comunidad ya que es posible hacer reseñas y luego cancelar la reserva repetidas veces.


